### PR TITLE
Correct font name to fix build on Linux

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -287,7 +287,7 @@ pub fn get_editor(
             ));
 
             let determination =
-                egui::FontData::from_static(include_bytes!("../assets/DTM-mono.otf"));
+                egui::FontData::from_static(include_bytes!("../assets/DTM-Mono.otf"));
 
             let mut fonts = FontDefinitions::default();
             fonts


### PR DESCRIPTION
On Linux path/filenames are case sensitive, this change should fix the error when building on Linux